### PR TITLE
Feature/fop 2371/tinycbor bump

### DIFF
--- a/cborattr/include/cborattr/cborattr.h
+++ b/cborattr/include/cborattr/cborattr.h
@@ -26,7 +26,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include "tinycbor/cbor.h"
+#include "cbor.h"
 
 #ifdef MYNEWT
 #include <os/os_mbuf.h>

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -36,9 +36,6 @@
 #define CBORATTR_MAX_SIZE MYNEWT_VAL(CBORATTR_MAX_SIZE)
 #endif
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(cborattr);
-
 /* this maps a CborType to a matching CborAtter Type. The mapping is not
  * one-to-one because of signedness of integers
  * and therefore we need a function to do this trickery */
@@ -394,8 +391,6 @@ int
 cbor_read_object(struct CborValue *value, const struct cbor_attr_t *attrs)
 {
     int st;
-
-    LOG_ERR("cbor_read_object at %X", value->ptr);
 
     st = cbor_internal_read_object(value, attrs, NULL, 0);
     return st;

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -18,8 +18,6 @@
  */
 
 #include "cborattr/cborattr.h"
-#include "tinycbor/cbor.h"
-#include "tinycbor/cbor_buf_reader.h"
 
 #ifdef __ZEPHYR__
 #include <zephyr.h>
@@ -37,6 +35,9 @@
 #include "os/os_mbuf.h"
 #define CBORATTR_MAX_SIZE MYNEWT_VAL(CBORATTR_MAX_SIZE)
 #endif
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(cborattr);
 
 /* this maps a CborType to a matching CborAtter Type. The mapping is not
  * one-to-one because of signedness of integers
@@ -394,6 +395,8 @@ cbor_read_object(struct CborValue *value, const struct cbor_attr_t *attrs)
 {
     int st;
 
+    LOG_ERR("cbor_read_object at %X", value->ptr);
+
     st = cbor_internal_read_object(value, attrs, NULL, 0);
     return st;
 }
@@ -412,13 +415,11 @@ int
 cbor_read_flat_attrs(const uint8_t *data, int len,
                      const struct cbor_attr_t *attrs)
 {
-    struct cbor_buf_reader reader;
     struct CborParser parser;
     struct CborValue value;
     CborError err;
 
-    cbor_buf_reader_init(&reader, data, len);
-    err = cbor_parser_init(&reader.r, 0, &parser, &value);
+    err = cbor_parser_init(data, len, 0, &parser, &value);
     if (err != CborNoError) {
         return -1;
     }
@@ -444,13 +445,11 @@ int
 cbor_read_mbuf_attrs(struct os_mbuf *m, uint16_t off, uint16_t len,
                      const struct cbor_attr_t *attrs)
 {
-    struct cbor_mbuf_reader cmr;
     struct CborParser parser;
     struct CborValue value;
     CborError err;
 
-    cbor_mbuf_reader_init(&cmr, m, off);
-    err = cbor_parser_init(&cmr.r, 0, &parser, &value);
+    err = cbor_parser_init(m + off, len, 0, &parser, &value);
     if (err != CborNoError) {
         return -1;
     }

--- a/cborattr/test/src/test_cborattr.h
+++ b/cborattr/test/src/test_cborattr.h
@@ -23,7 +23,7 @@
 #include <string.h>
 #include "testutil/testutil.h"
 #include "test_cborattr.h"
-#include "tinycbor/cbor.h"
+#include "cbor.h"
 #include "cborattr/cborattr.h"
 
 #ifdef __cplusplus

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -20,9 +20,6 @@
 #ifndef H_IMG_MGMT_CONFIG_
 #define H_IMG_MGMT_CONFIG_
 
-/* Number of updatable images */
-#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER 1
-
 #if defined MYNEWT
 
 #include "syscfg/syscfg.h"
@@ -40,8 +37,7 @@
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
-#undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
-#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#else
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -36,29 +36,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <img_mgmt/image.h>
 #include "../../../src/img_mgmt_priv.h"
 
-BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1 ||
-             (CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 &&
-              FLASH_AREA_LABEL_EXISTS(image_2) &&
-              FLASH_AREA_LABEL_EXISTS(image_3)),
-              "Missing partitions?");
-
-static int
-zephyr_img_mgmt_slot_to_image(int slot)
-{
-    switch (slot) {
-    case 0:
-    case 1:
-        return 0;
-#if FLASH_AREA_LABEL_EXISTS(image_2) && FLASH_AREA_LABEL_EXISTS(image_3)
-    case 2:
-    case 3:
-        return 1;
-#endif
-    default:
-        assert(0);
-    }
-    return 0;
-}
 /**
  * Determines if the specified area of flash is completely unwritten.
  */
@@ -153,7 +130,6 @@ zephyr_img_mgmt_flash_area_id(int slot)
     return fa_id;
 }
 
-#if CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1
 /**
  * In normal operation this function will select between first two slot
  * (in reality it just checks whether second slot can be used), ignoring the
@@ -199,27 +175,6 @@ img_mgmt_get_unused_slot_area_id(int slot)
     return slot != -1  ? zephyr_img_mgmt_flash_area_id(slot) : -1;
 #endif
 }
-#elif CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2
-static int
-img_mgmt_get_unused_slot_area_id(int image)
-{
-    int area_id = -1;
-
-    if (image == 0) {
-        if (img_mgmt_slot_in_use(1) == 0) {
-            area_id = zephyr_img_mgmt_flash_area_id(1);
-        }
-    } else if (image == 1) {
-        area_id = zephyr_img_mgmt_flash_area_id(3);
-    } else {
-        assert(0);
-    }
-
-    return area_id;
-}
-#else
-#error "Unsupported number of images"
-#endif
 
 /**
  * Compares two image version numbers in a semver-compatible way.
@@ -288,13 +243,11 @@ img_mgmt_impl_write_pending(int slot, bool permanent)
 {
     int rc;
 
-    if (slot != 1 &&
-        !(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 && slot == 3)) {
+    if (slot != 1) {
         return MGMT_ERR_EINVAL;
     }
 
-    rc = boot_request_upgrade_multi(zephyr_img_mgmt_slot_to_image(slot),
-                                    permanent);
+    rc = boot_request_upgrade(permanent);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }
@@ -473,9 +426,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 int
 img_mgmt_impl_swap_type(int slot)
 {
-    int image = zephyr_img_mgmt_slot_to_image(slot);
-
-    switch (mcuboot_swap_type_multi(image)) {
+    switch (mcuboot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;
     case BOOT_SWAP_TYPE_TEST:

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -241,7 +241,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
     int i;
     struct image_version ver;
 
-    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2; i++) {
         if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
             continue;
         }
@@ -262,7 +262,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
     int i;
     uint8_t hash[IMAGE_HASH_LEN];
 
-    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2; i++) {
         if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
             continue;
         }

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 
-#include "tinycbor/cbor.h"
+#include "cbor.h"
 #include "cborattr/cborattr.h"
 #include "mgmt/mgmt.h"
 #include "img_mgmt/img_mgmt.h"

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -204,7 +204,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
     err |= cbor_encoder_create_array(&ctxt->encoder, &images,
                                        CborIndefiniteLength);
 
-    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2; i++) {
         rc = img_mgmt_read_info(i, &ver, hash, &flags);
         if (rc != 0) {
             continue;
@@ -215,10 +215,6 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
         err |= cbor_encoder_create_map(&images, &image,
                                          CborIndefiniteLength);
 
-#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
-        err |= cbor_encode_text_stringz(&image, "image");
-        err |= cbor_encode_int(&image, i >> 1);
-#endif
         err |= cbor_encode_text_stringz(&image, "slot");
         err |= cbor_encode_int(&image, i % 2);
 

--- a/cmd/os_mgmt/src/os_mgmt.c
+++ b/cmd/os_mgmt/src/os_mgmt.c
@@ -27,9 +27,6 @@
 #include "os_mgmt/os_mgmt_impl.h"
 #include "os_mgmt/os_mgmt_config.h"
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(os_mgmt);
-
 #if OS_MGMT_ECHO
 static mgmt_handler_fn os_mgmt_echo;
 #endif
@@ -91,20 +88,13 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
     echo_buf[0] = '\0';
 
     err = cbor_read_object(&ctxt->it, attrs);
-    LOG_ERR("os_mgmt_echo: cbor_read_object %d", err);
     if (err != 0) {
         return MGMT_ERR_EINVAL;
     }
 
-    LOG_ERR("os_mgmt_echo: decoded echo string %s", log_strdup(echo_buf));
-
-    LOG_ERR("os_mgmt_echo: encoding echo response into address %X", ctxt->encoder.data.ptr);
-
     /* encode a mapped key-value pair 'r=...' */
     err |= cbor_encode_text_stringz(&ctxt->encoder, "r");
-    LOG_ERR("os_mgmt_echo: after encoding 'r' address is at %X", ctxt->encoder.data.ptr);
     err |= cbor_encode_text_string(&ctxt->encoder, echo_buf, strlen(echo_buf));
-    LOG_ERR("os_mgmt_echo: after encoding 'echo_buf' address is at %X", ctxt->encoder.data.ptr);
 
     if (err != 0) {
         return MGMT_ERR_ENOMEM;

--- a/cmd/os_mgmt/src/os_mgmt.c
+++ b/cmd/os_mgmt/src/os_mgmt.c
@@ -96,7 +96,7 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
         return MGMT_ERR_EINVAL;
     }
 
-    LOG_ERR("os_mgmt_echo: decoded echo string %s", echo_buf);
+    LOG_ERR("os_mgmt_echo: decoded echo string %s", log_strdup(echo_buf));
 
     LOG_ERR("os_mgmt_echo: encoding echo response into address %X", ctxt->encoder.data.ptr);
 

--- a/cmd/os_mgmt/src/os_mgmt.c
+++ b/cmd/os_mgmt/src/os_mgmt.c
@@ -20,12 +20,15 @@
 #include <assert.h>
 #include <string.h>
 
-#include "tinycbor/cbor.h"
+#include "cbor.h"
 #include "cborattr/cborattr.h"
 #include "mgmt/mgmt.h"
 #include "os_mgmt/os_mgmt.h"
 #include "os_mgmt/os_mgmt_impl.h"
 #include "os_mgmt/os_mgmt_config.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(os_mgmt);
 
 #if OS_MGMT_ECHO
 static mgmt_handler_fn os_mgmt_echo;
@@ -88,12 +91,20 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
     echo_buf[0] = '\0';
 
     err = cbor_read_object(&ctxt->it, attrs);
+    LOG_ERR("os_mgmt_echo: cbor_read_object %d", err);
     if (err != 0) {
         return MGMT_ERR_EINVAL;
     }
 
+    LOG_ERR("os_mgmt_echo: decoded echo string %s", echo_buf);
+
+    LOG_ERR("os_mgmt_echo: encoding echo response into address %X", ctxt->encoder.data.ptr);
+
+    /* encode a mapped key-value pair 'r=...' */
     err |= cbor_encode_text_stringz(&ctxt->encoder, "r");
+    LOG_ERR("os_mgmt_echo: after encoding 'r' address is at %X", ctxt->encoder.data.ptr);
     err |= cbor_encode_text_string(&ctxt->encoder, echo_buf, strlen(echo_buf));
+    LOG_ERR("os_mgmt_echo: after encoding 'echo_buf' address is at %X", ctxt->encoder.data.ptr);
 
     if (err != 0) {
         return MGMT_ERR_ENOMEM;

--- a/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/include/mgmt/mgmt.h
@@ -21,7 +21,9 @@
 #define H_MGMT_MGMT_
 
 #include <inttypes.h>
-#include "tinycbor/cbor.h"
+#include "cbor.h"
+
+#include "mgmt/mcumgr/buf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -171,7 +173,7 @@ typedef void mgmt_reset_buf_fn(void *buf, void *arg);
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int mgmt_write_at_fn(struct cbor_encoder_writer *writer, size_t offset,
+typedef int mgmt_write_at_fn(struct cbor_nb_writer *writer, size_t offset,
                              const void *data, size_t len, void *arg);
 
 /** @typedef mgmt_init_reader_fn
@@ -183,7 +185,7 @@ typedef int mgmt_write_at_fn(struct cbor_encoder_writer *writer, size_t offset,
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int mgmt_init_reader_fn(struct cbor_decoder_reader *reader, void *buf,
+typedef int mgmt_init_reader_fn(struct cbor_nb_reader *reader, void *buf,
                                 void *arg);
 
 /** @typedef mgmt_init_writer_fn
@@ -195,7 +197,7 @@ typedef int mgmt_init_reader_fn(struct cbor_decoder_reader *reader, void *buf,
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int mgmt_init_writer_fn(struct cbor_encoder_writer *writer, void *buf,
+typedef int mgmt_init_writer_fn(struct cbor_nb_writer *writer, void *buf,
                                 void *arg);
 
 /** @typedef mgmt_init_writer_fn
@@ -225,18 +227,23 @@ struct mgmt_streamer_cfg {
 struct mgmt_streamer {
     const struct mgmt_streamer_cfg *cfg;
     void *cb_arg;
-    struct cbor_decoder_reader *reader;
-    struct cbor_encoder_writer *writer;
+    struct cbor_nb_reader reader;
+    struct cbor_nb_writer writer;
 };
 
+
+struct buffer_ctxt {
+    void *buffer;
+    size_t size;
+};
 /**
  * @brief Context required by command handlers for parsing requests and writing
  *        responses.
  */
 struct mgmt_ctxt {
-    struct CborEncoder encoder;
-    struct CborParser parser;
-    struct CborValue it;
+    CborEncoder encoder;
+    CborParser parser;
+    CborValue it;
 };
 
 /** @typedef mgmt_handler_fn
@@ -400,12 +407,12 @@ int mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int status);
  * @brief Initializes a management context object with the specified streamer.
  *
  * @param ctxt                  The context object to initialize.
- * @param streamer              The streamer that will be used with the
- *                                  context.
+ * @param encoder_buffer_ctxt   The context object holding the buffer for encoding into
+ * @param decoder_buffer_ctxt   The context object holding the buffer for decoding from.
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-int mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct mgmt_streamer *streamer);
+int mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct buffer_ctxt *encoder_buffer_ctxt, struct buffer_ctxt *decoder_buffer_ctxt);
 
 /**
  * @brief Converts a CBOR status code to a MGMT_ERR_[...] code.

--- a/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/include/mgmt/mgmt.h
@@ -231,8 +231,11 @@ struct mgmt_streamer {
     struct cbor_nb_writer writer;
 };
 
-
-struct buffer_ctxt {
+/**
+ * @brief Wrapper structure to pass around a buffer and its size,
+ *        pointing to a decode/encode buffer
+ */
+struct mgmt_buffer {
     void *buffer;
     size_t size;
 };
@@ -407,12 +410,12 @@ int mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int status);
  * @brief Initializes a management context object with the specified streamer.
  *
  * @param ctxt                  The context object to initialize.
- * @param encoder_buffer_ctxt   The context object holding the buffer for encoding into
- * @param decoder_buffer_ctxt   The context object holding the buffer for decoding from.
+ * @param encoder_buffer        The wrapper object holding the buffer for encoding into.
+ * @param decoder_buffer        The wrapper object holding the buffer for decoding from.
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-int mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct buffer_ctxt *encoder_buffer_ctxt, struct buffer_ctxt *decoder_buffer_ctxt);
+int mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct mgmt_buffer *encoder_buffer, struct mgmt_buffer *decoder_buffer);
 
 /**
  * @brief Converts a CBOR status code to a MGMT_ERR_[...] code.

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -182,16 +182,16 @@ mgmt_err_from_cbor(int cbor_status)
 }
 
 int
-mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct buffer_ctxt *encoder_buffer_ctxt, struct buffer_ctxt *decoder_buffer_ctxt)
+mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct mgmt_buffer *encoder_buffer, struct mgmt_buffer *decoder_buffer)
 {
     CborError rc;
 
-    rc = cbor_parser_init(decoder_buffer_ctxt->buffer, decoder_buffer_ctxt->size, 0, &ctxt->parser, &ctxt->it);
+    rc = cbor_parser_init(decoder_buffer->buffer, decoder_buffer->size, 0, &ctxt->parser, &ctxt->it);
     if (rc != CborNoError) {
         return mgmt_err_from_cbor(rc);
     }
 
-    cbor_encoder_init(&ctxt->encoder, encoder_buffer_ctxt->buffer, encoder_buffer_ctxt->size, 0);
+    cbor_encoder_init(&ctxt->encoder, encoder_buffer->buffer, encoder_buffer->size, 0);
 
     return 0;
 }

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -23,9 +23,6 @@
 #include "mgmt/endian.h"
 #include "mgmt/mgmt.h"
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(mgmt);
-
 static mgmt_on_evt_cb *evt_cb;
 static struct mgmt_group *mgmt_group_list;
 static struct mgmt_group *mgmt_group_list_end;
@@ -141,7 +138,6 @@ mgmt_register_group(struct mgmt_group *group)
         mgmt_group_list_end->mg_next = group;
     }
     mgmt_group_list_end = group;
-    LOG_ERR("mgmt_register_group: registered groupId %d", group->mg_group_id);
 }
 
 const struct mgmt_handler *

--- a/omp/port/mynewt/src/mynewt_omp.c
+++ b/omp/port/mynewt/src/mynewt_omp.c
@@ -24,7 +24,6 @@
 
 #include <mgmt/mgmt.h>
 #include <cborattr/cborattr.h>
-#include <tinycbor/cbor.h>
 
 #include "omp/omp.h"
 #include "omp/omp_priv.h"

--- a/smp/src/smp.c
+++ b/smp/src/smp.c
@@ -96,8 +96,8 @@ smp_build_err_rsp(struct smp_streamer *streamer,
 {
     struct mgmt_ctxt cbuf;
     struct mgmt_hdr rsp_hdr;
-    struct buffer_ctxt encBuf;
-    struct buffer_ctxt decBuf;
+    struct mgmt_buffer encBuf;
+    struct mgmt_buffer decBuf;
     int rc;
 
     /* encoding should happen on the payload_encoder and not on the cbuf.encoder
@@ -250,8 +250,8 @@ smp_handle_single_req(struct smp_streamer *streamer,
 {
     struct mgmt_ctxt cbuf;
     struct mgmt_hdr rsp_hdr;
-    struct buffer_ctxt encBuf;
-    struct buffer_ctxt decBuf;
+    struct mgmt_buffer encBuf;
+    struct mgmt_buffer decBuf;
     int rc;
 
     /* give the netbuffer memory region to the cbor encoder but with an offset where the header is placed */

--- a/smp/src/smp.c
+++ b/smp/src/smp.c
@@ -29,9 +29,6 @@
 
 #include "net/buf.h"
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(smp_mcumgr);
-
 static int
 smp_align4(int x)
 {
@@ -189,9 +186,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf,
     int rc;
 
     handler = mgmt_find_handler(req_hdr->nh_group, req_hdr->nh_id);
-    LOG_ERR("smp_handle_single_payload: mgmt_find_handler returned ptr %X", handler);
     if (handler == NULL) {
-        LOG_ERR("smp_handle_single_payload: failed to find handler for groupId %d and commandId %d", req_hdr->nh_group, req_hdr->nh_id);
         return MGMT_ERR_ENOTSUP;
     }
 
@@ -200,9 +195,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf,
      */
     rc = cbor_encoder_create_map(&cbuf->encoder, &payload_ctxt.encoder,
                                  CborIndefiniteLength);
-    LOG_ERR("smp_handle_single_payload: cbor_encoder_create_map %d", rc);
     rc = mgmt_err_from_cbor(rc);
-    LOG_ERR("smp_handle_single_payload: mgmt_err_from_cbor %d", rc);
     if (rc != 0) {
         return rc;
     }
@@ -225,10 +218,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf,
         mgmt_evt(MGMT_EVT_OP_CMD_RECV, req_hdr->nh_group, req_hdr->nh_id, NULL);
 
         rc = handler_fn(&payload_ctxt);
-        LOG_ERR("smp_handle_single_payload: handler_fn %d", rc);
-        LOG_ERR("smp_handle_single_payload: after calling handler data ptr is at %X", cbuf->encoder.data.ptr);
     } else {
-        LOG_ERR("smp_handle_single_payload: handler_found unset %d", req_hdr->nh_op);
         rc = MGMT_ERR_ENOTSUP;
     }
 
@@ -238,8 +228,6 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf,
 
     /* End response payload. */
     rc = cbor_encoder_close_container(&cbuf->encoder, &payload_ctxt.encoder);
-    LOG_ERR("smp_handle_single_payload: cbor_encoder_close_container %d", rc);
-    LOG_ERR("smp_handle_single_payload: after closing container data ptr is at %X", cbuf->encoder.data.ptr);
     return mgmt_err_from_cbor(rc);
 }
 
@@ -274,7 +262,6 @@ smp_handle_single_req(struct smp_streamer *streamer,
     decBuf.size = streamer->mgmt_stmr.reader.nb->len;/* use the actual nr of encoded bytes in the buffer, not the max size */
 
     rc = mgmt_ctxt_init(&cbuf, &encBuf, &decBuf);
-    LOG_ERR("smp_handle_single_req: mgmt_ctxt_init %d", rc);
     if (rc != 0) {
         return rc;
     }
@@ -283,32 +270,23 @@ smp_handle_single_req(struct smp_streamer *streamer,
      * fields will need to be fixed up later.
      */
     smp_init_rsp_hdr(req_hdr, &rsp_hdr);
-    LOG_ERR("smp_handle_single_req: writing dummy response header of size %d to %X", sizeof(rsp_hdr), streamer->mgmt_stmr.writer.encoder.data.ptr);
     rc = smp_write_hdr(streamer, &rsp_hdr);
-    LOG_ERR("smp_handle_single_req: smp_write_hdr %d", rc);
     if (rc != 0) {
         return rc;
     }
 
     /* Process the request and write the response payload. */
-    LOG_ERR("smp_handle_single_req: writing response data to %X", cbuf.encoder.data.ptr);
     rc = smp_handle_single_payload(&cbuf, req_hdr, handler_found);
-    LOG_ERR("smp_handle_single_req: smp_handle_single_payload %d", rc);
     if (rc != 0) {
         return rc;
     }
-
-    LOG_ERR("smp_handle_single_req: after writing response data ptr is at %X, start address %X", cbuf.encoder.data.ptr, encBuf.buffer);
-    LOG_ERR("smp_handle_single_req: nr encoded response bytes %d", cbor_encoder_get_buffer_size(&cbuf.encoder, encBuf.buffer));
 
     /* Fix up the response header with the correct length. */
     rsp_hdr.nh_len = cbor_encoder_get_buffer_size(&cbuf.encoder, encBuf.buffer);
     /* update the netbuffer length, used in outputting the packet */
     streamer->mgmt_stmr.writer.nb->len += rsp_hdr.nh_len;
     mgmt_hton_hdr(&rsp_hdr);
-    LOG_ERR("smp_handle_single_req: writing actual response header of size %d to %X", sizeof(rsp_hdr), streamer->mgmt_stmr.writer.encoder.data.ptr);
     rc = smp_write_hdr(streamer, &rsp_hdr);
-    LOG_ERR("smp_handle_single_req: smp_write_hdr %d", rc);
     if (rc != 0) {
         return rc;
     }
@@ -384,16 +362,10 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
     rsp = NULL;
     valid_hdr = true;
 
-    int loop_cnt = 0;
-
     while (1) {
-        loop_cnt++;
-        LOG_ERR("smp_process_request_packet: entered loop cnt %d", loop_cnt);
-
         handler_found = false;
 
         rc = mgmt_streamer_init_reader(&streamer->mgmt_stmr, req);
-        LOG_ERR("smp_process_request_packet: mgmt_streamer_init_reader %d", rc);
         if (rc != 0) {
             valid_hdr = false;
             break;
@@ -401,43 +373,32 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 
         /* Read the management header and strip it from the request. */
         rc = smp_read_hdr(streamer, &req_hdr);
-        LOG_ERR("smp_process_request_packet: smp_read_hdr %d from address %X", rc, streamer->mgmt_stmr.reader.nb->data);
         if (rc != 0) {
             valid_hdr = false;
             break;
         }
         mgmt_ntoh_hdr(&req_hdr);
-
-        LOG_ERR("smp_process_request_packet: decoded header into groupId %d and commandId %d", req_hdr.nh_group, req_hdr.nh_id);
-        LOG_ERR("smp_process_request_packet: CBorValue iterator ptr at address %X", streamer->mgmt_stmr.reader.it.ptr);
-        
         mgmt_streamer_trim_front(&streamer->mgmt_stmr, req, MGMT_HDR_SIZE);
 
         rsp = mgmt_streamer_alloc_rsp(&streamer->mgmt_stmr, req);
-        LOG_ERR("smp_process_request_packet: mgmt_streamer_alloc_rsp ptr %X", rsp);
         if (rsp == NULL) {
             rc = MGMT_ERR_ENOMEM;
             break;
         }
 
         rc = mgmt_streamer_init_writer(&streamer->mgmt_stmr, rsp);
-        LOG_ERR("smp_process_request_packet: mgmt_streamer_init_writer %d", rc);
         if (rc != 0) {
             break;
         }
 
-        LOG_ERR("smp_process_request_packet: set writer ptr to %X", streamer->mgmt_stmr.writer.encoder.data.ptr);
-
         /* Process the request payload and build the response. */
         rc = smp_handle_single_req(streamer, &req_hdr, &handler_found);
-        LOG_ERR("smp_process_request_packet: smp_handle_single_req %d", rc);
         if (rc != 0) {
             break;
         }
 
         /* Send the response. */
         rc = streamer->tx_rsp_cb(streamer, rsp, streamer->mgmt_stmr.cb_arg);
-        LOG_ERR("smp_process_request_packet: tx_rsp_cb %d", rc);
         rsp = NULL;
         if (rc != 0) {
             break;


### PR DESCRIPTION
This PR is part of a bigger scheme to support updating the process-controller: https://nobleo-embedded.atlassian.net/browse/FOP-2371

- Bumped code compatibility version to tinycbor to 0.5.4, required to prevent collision of Optima tinycbor version and Zephyr tinycbor version.
- Removed unsupported image slot selection functionality, as this has a direct dependency to Zephyr version > v2.6
